### PR TITLE
docs: fix typeco module

### DIFF
--- a/website/docs/guide/advanced/performance.md
+++ b/website/docs/guide/advanced/performance.md
@@ -238,7 +238,7 @@ const App = () => {
 
 ```js
 // webpack.config.js
-mmodule.exports = {
+module.exports = {
   // ...
   externals: {
     'react': 'React',


### PR DESCRIPTION
`mmodule` 错别字修改为 `module` 